### PR TITLE
Check if accountId is onboarded

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -62,6 +62,10 @@ export function onboardAccount(accountId: string): u8 {
 	return 1;
 }
 
+export function isAccountOnboarded(accountId: string): bool {
+	return onboardLookup.contains(accountId);
+}
+
 export function usernameInRange(username: string): bool {
 	const len = username.length;
 	for (let i = 0; i < len; i++) {


### PR DESCRIPTION
Created a view method to check if an accountId is already onboarded. To be used in capsule-server. Corresponding PR to follow. 

Test contract deployed on: `dev-1643261671971-43501821334444`